### PR TITLE
enable GA for landing pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express": "^4.17.1",
     "leaflet": "^1.7.1",
     "vue": "^2.6.12",
+    "vue-gtag": "^1.14.0",
     "vue-router": "^3.5.1",
     "vue-template-compiler": "^2.6.12",
     "vue2-leaflet": "^1.2.3",

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,10 @@
-import Vue from 'vue'
+import Vue from 'vue';
 import VueRouter from 'vue-router';
+import VueGtag from 'vue-gtag';
 // import BootstrapVue from 'bootstrap-vue'
 
 import App from './App.vue'
-import "leaflet/dist/leaflet.css";
+import 'leaflet/dist/leaflet.css';
 
 import { BContainer, BCol, BRow, BCard, BTooltip } from 'bootstrap-vue';
 Vue.component('b-container', BContainer);
@@ -18,15 +19,15 @@ Vue.component('l-tile-layer', LTileLayer);
 Vue.component('l-marker', LMarker);
 
 // eslint-disable-next-line
-delete L.Icon.Default.prototype._getIconUrl
+delete L.Icon.Default.prototype._getIconUrl;
 // eslint-disable-next-line
 L.Icon.Default.mergeOptions({
   iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
   iconUrl: require('leaflet/dist/images/marker-icon.png'),
   shadowUrl: require('leaflet/dist/images/marker-shadow.png')
-})
+});
 
-Vue.config.productionTip = false
+Vue.config.productionTip = false;
 
 const router = new VueRouter({
   mode: 'history',
@@ -37,24 +38,27 @@ const router = new VueRouter({
       name: 'root'
     },
     {
-      path: "/:dsid/",
+      path: '/:dsid/',
       component: App,
       props: true
     },
     {
-      path: "/datasets/:dsid/",
-      alias: "/:dsid",
+      path: '/datasets/:dsid/',
+      alias: '/:dsid',
       component: App,
       props: true
     }
   ]
-})
+});
 
-Vue.use(VueRouter)
+Vue.use(VueRouter);
+Vue.use(VueGtag, {
+  config: { id: 'G-3XDNWKENJ4' }
+}, router);
 // Vue.use(BootstrapVue)
 
 new Vue({
   el: '#app',
   router: router,
   render: h => h('router-view')
-})
+});


### PR DESCRIPTION
This PR enables Google Analytics for data landing pages via a new dependency, `vue-gtag`, and revisions to the src/`main.js` script. 

cc @SimonGoring 