### PR TITLE
Throughput widget testing code

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,10 @@
     <title>NeotomaDB DOIs</title>
   </head>
   <body>
+    <!-- would usually use npm to install throughput-widget, but not here since we want easy access to the dev version -->
+    <!-- DEV -->
+    <script type="module" src="http://localhost:3333/build/throughputwidget.esm.js"></script>
+    <!-- <script type="module" src="https://unpkg.com/throughput-widget/dist/throughputwidget/throughputwidget.js"></script> -->
     <noscript>
       <strong>We're sorry but landingpages doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>

--- a/src/components/titlecard.vue
+++ b/src/components/titlecard.vue
@@ -14,6 +14,15 @@
             The dynamic site map is not displayed on mobile displays.  Use the Neotoma Explorer link.<br>
             <small><strong>Coordinates</strong>: {{items.coord}}</small>
           </div>
+          <!-- remember to use dash case for Stencil-side readOnlymode prop! -->
+          <throughput-widget
+            read-only-mode="false"
+            identifier="r3d100011761"
+            additional-type="site"
+            :link.prop="this.dsid"
+            orcid-client-id="APP-BKBMDK2CLSW85I2Z"
+            token="gaWSg#B4H*wy9a-d">
+          </throughput-widget>
         </div>
 
         <div class='mapbox d-none d-sm-block'  v-b-tooltip.hover :title="attribution">

--- a/src/main.js
+++ b/src/main.js
@@ -27,6 +27,7 @@ L.Icon.Default.mergeOptions({
   shadowUrl: require('leaflet/dist/images/marker-shadow.png')
 });
 
+Vue.config.productionTip = false
 Vue.config.ignoredElements = ["throughput-widget"];
 
 const router = new VueRouter({

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ L.Icon.Default.mergeOptions({
   shadowUrl: require('leaflet/dist/images/marker-shadow.png')
 });
 
-Vue.config.productionTip = false;
+Vue.config.ignoredElements = ["throughput-widget"];
 
 const router = new VueRouter({
   mode: 'history',


### PR DESCRIPTION
Add the Throughput widget (assumes it's locally installed and running on localhost:3333) to site landing pages for testing purposes.  Try dataset 2662, which already has some annotations.